### PR TITLE
Update Dependabot Time

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,4 @@ updates:
     directory: "."
     schedule:
       interval: "daily"
-      time: "18:00"
+      time: "19:30"


### PR DESCRIPTION
Update scan time to ensure dependabot runs today.